### PR TITLE
feat(simulation): adicionar sistema de substituições manuais, pausa d…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #d40000;
   }
 }
 

--- a/src/app/match/page.tsx
+++ b/src/app/match/page.tsx
@@ -1,35 +1,107 @@
 'use client';
 import { useState } from 'react';
 import { teams } from '../../data/teams';
-import { simulateMatchAsync, MatchResult, PlayerStats } from '../../utils/simulation';
+import { simulateMatchAsync, MatchResult, PlayerStats, pauseSimulation, resumeSimulation, substitutePlayer } from '../../utils/simulation';
 
 export default function MatchPage() {
   const [result, setResult] = useState<MatchResult | null>(null);
   const [loading, setLoading] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [showSubs, setShowSubs] = useState(false);
 
   const handleSimulate = async () => {
     setLoading(true);
     setResult(null);
-    await simulateMatchAsync(teams[0], teams[1], (events, score, quarterScores, boxscore) => {
-      setResult({ events, score, quarterScores, boxscore });
+    await simulateMatchAsync(teams[0], teams[1], (events, score, quarterScores, boxscore, starters, bench) => {
+      setResult({ events, score, quarterScores, boxscore, starters, bench });
     });
     setLoading(false);
+  };
+
+  const handlePause = () => {
+    pauseSimulation();
+    setPaused(true);
+  };
+
+  const handleResume = () => {
+    resumeSimulation();
+    setPaused(false);
+    setShowSubs(false);
+  };
+
+  const handleSubstitute = (teamId: string, outPlayer: string, inPlayer: string) => {
+    if (!result) return;
+
+    const outP = result.starters[teamId].find(p => p.name === outPlayer);
+    const inP = result.bench[teamId].find(p => p.name === inPlayer);
+
+    if (!outP || !inP) return;
+
+    substitutePlayer(teamId, outP, inP, result.starters, result.bench);
+    setResult({ ...result }); // força atualização visual
   };
 
   return (
     <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
       <h1>Partida: {teams[0].name} vs {teams[1].name}</h1>
 
-      <button
-        onClick={handleSimulate}
-        disabled={loading}
-        style={{ marginTop: '1rem', padding: '0.5rem 1rem' }}
-      >
-        {loading ? 'Simulando...' : 'Simular Partida'}
-      </button>
+      {!result && (
+        <button
+          onClick={handleSimulate}
+          disabled={loading}
+          style={{ marginTop: '1rem', padding: '0.5rem 1rem' }}
+        >
+          {loading ? 'Simulando...' : 'Simular Partida'}
+        </button>
+      )}
 
       {result && (
         <div>
+          <div style={{ margin: '1rem 0' }}>
+            {!paused ? (
+              <button onClick={handlePause} style={{ marginRight: '1rem' }}>⏸️ Pausar</button>
+            ) : (
+              <>
+                <button onClick={() => setShowSubs(true)} style={{ marginRight: '1rem' }}>🔄 Substituições</button>
+                <button onClick={handleResume}>▶️ Continuar</button>
+              </>
+            )}
+          </div>
+
+          {showSubs && (
+            <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+              <h3>Gerenciar Substituições</h3>
+              {[teams[0], teams[1]].map(team => (
+                <div key={team.id} style={{ marginBottom: '1rem' }}>
+                  <h4>{team.name}</h4>
+                  <p><b>Titulares</b></p>
+                  <ul>
+                    {result.starters[team.id].map(p => (
+                      <li key={p.name}>
+                        {p.name} ({p.position})
+                        <select
+                          defaultValue=""
+                          onChange={e => {
+                            if (e.target.value) {
+                              handleSubstitute(team.id, p.name, e.target.value);
+                              e.target.value = "";
+                            }
+                          }}
+                        >
+                          <option value="" disabled>Substituir por...</option>
+                          {result.bench[team.id].map(b => (
+                            <option key={b.name} value={b.name}>{b.name} ({b.position})</option>
+                          ))}
+                        </select>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+              <button onClick={() => setShowSubs(false)}>Fechar</button>
+            </div>
+          )}
+
           <h2>Resultado Final</h2>
           <p>{teams[0].name}: {result.score[teams[0].id]}</p>
           <p>{teams[1].name}: {result.score[teams[1].id]}</p>
@@ -68,7 +140,7 @@ export default function MatchPage() {
                         <td>{s.fgm}/{s.fga}</td>
                         <td>{s.tpm}/{s.tpa}</td>
                         <td>{s.ftm}/{s.fta}</td>
-                        <td>{s.energy}</td>
+                        <td>{Math.round(s.energy)}</td>
                       </tr>
                     );
                   })}

--- a/src/utils/simulation.ts
+++ b/src/utils/simulation.ts
@@ -1,206 +1,240 @@
 import { Team, Player } from '../data/teams';
 
 export type PlayerStats = {
-  points: number;
-  fgm: number; // Field Goals Made
-  fga: number; // Field Goals Attempted
-  tpm: number; // 3 Points Made
-  tpa: number; // 3 Points Attempted
-  ftm: number; // Free Throws Made
-  fta: number; // Free Throws Attempted
-  energy: number; // Energy level (0-100)
+    points: number;
+    fgm: number; // Field Goals Made
+    fga: number; // Field Goals Attempted
+    tpm: number; // 3 Points Made
+    tpa: number; // 3 Points Attempted
+    ftm: number; // Free Throws Made
+    fta: number; // Free Throws Attempted
+    energy: number; // Energy level (0-100)
 };
 
 export type MatchResult = {
-  score: Record<string, number>;
-  quarterScores: Record<string, number[]>;
-  events: string[];
-  boxscore: Record<string, Record<string, PlayerStats>>;
+    score: Record<string, number>;
+    quarterScores: Record<string, number[]>;
+    events: string[];
+    boxscore: Record<string, Record<string, PlayerStats>>;
+    starters: Record<string, Player[]>;
+    bench: Record<string, Player[]>;
 };
 
 function randomChance(probability: number): boolean {
-  return Math.random() < probability;
+    return Math.random() < probability;
 }
 
 function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 // titulares (1 por posição)
 function getStarters(players: Player[]): Player[] {
-  const positions = ["PG", "SG", "SF", "PF", "C"];
-  return positions.map(pos => players.find(p => p.position === pos)!).filter(Boolean);
+    const positions = ["PG", "SG", "SF", "PF", "C"];
+    return positions.map(pos => players.find(p => p.position === pos)!).filter(Boolean);
 }
 
-// substituição automática
-function substitutePlayer(
-  teamPlayers: Player[],
-  onCourt: Player[],
-  position: string,
-  events: string[],
-  minute: number,
-  second: number
+// Controle de pausa
+let paused = false;
+let resolvePause: (() => void) | null = null;
+
+export function pauseSimulation() {
+    paused = true;
+}
+
+export function resumeSimulation() {
+    paused = false;
+    if (resolvePause) {
+        resolvePause();
+        resolvePause = null;
+    }
+}
+
+// Substituição manual de jogador
+export function substitutePlayer(
+    teamId: string,
+    outPlayer: Player,
+    inPlayer: Player,
+    starters: Record<string, Player[]>,
+    bench: Record<string, Player[]>
 ) {
-  const tiredPlayer = onCourt.find(p => p.position === position);
-  const benchPlayer = teamPlayers.find(p => p.position === position && !onCourt.includes(p));
+    // remove titular
+    starters[teamId] = starters[teamId].filter(p => p.name !== outPlayer.name);
 
-  if (tiredPlayer && benchPlayer) {
-    const idx = onCourt.indexOf(tiredPlayer);
-    onCourt[idx] = benchPlayer;
+    // adiciona titular
+    starters[teamId].push(inPlayer);
 
-    events.push(
-      `[${minute}:${second < 10 ? '0' : ''}${second}] Substituição: ${tiredPlayer.name} sai, ${benchPlayer.name} entra (${position}).`
-    );
-  }
+    // atualiza reservas
+    bench[teamId] = bench[teamId].filter(p => p.name !== inPlayer.name);
+    bench[teamId].push(outPlayer);
 }
 
 export async function simulateMatchAsync(
-  teamA: Team,
-  teamB: Team,
-  onUpdate?: (
-    events: string[],
-    score: Record<string, number>,
-    quarterScores: Record<string, number[]>,
-    boxscore: Record<string, Record<string, PlayerStats>>
-  ) => void
+    teamA: Team,
+    teamB: Team,
+    onUpdate?: (
+        events: string[],
+        score: Record<string, number>,
+        quarterScores: Record<string, number[]>,
+        boxscore: Record<string, Record<string, PlayerStats>>,
+        starters: Record<string, Player[]>,
+        bench: Record<string, Player[]>
+    ) => void
 ): Promise<MatchResult> {
-  const score: Record<string, number> = {
-    [teamA.id]: 0,
-    [teamB.id]: 0
-  };
 
-  const quarterScores: Record<string, number[]> = {
-    [teamA.id]: [0, 0, 0, 0],
-    [teamB.id]: [0, 0, 0, 0]
-  };
-
-  const boxscore: Record<string, Record<string, PlayerStats>> = {
-    [teamA.id]: {},
-    [teamB.id]: {}
-  };
-
-  const events: string[] = [];
-
-  const quarters = 4;
-  const quarterTime = 12 * 60;
-
-  const playersA: Player[] = teamA.players.map(p => ({ ...p }));
-  const playersB: Player[] = teamB.players.map(p => ({ ...p }));
-
-  let onCourtA = getStarters(playersA);
-  let onCourtB = getStarters(playersB);
-
-  // inicializa stats
-  [...playersA, ...playersB].forEach(p => {
-    boxscore[p.teamId] = boxscore[p.teamId] || {};
-    boxscore[p.teamId][p.name] = {
-      points: 0,
-      fgm: 0,
-      fga: 0,
-      tpm: 0,
-      tpa: 0,
-      ftm: 0,
-      fta: 0,
-      energy: p.energy
-
+    const score: Record<string, number> = {
+        [teamA.id]: 0,
+        [teamB.id]: 0
     };
-  });
 
-  for (let q = 1; q <= quarters; q++) {
-    events.push(`--- Quarter ${q} ---`);
-    if (onUpdate) onUpdate([...events], { ...score }, { ...quarterScores }, { ...boxscore });
+    const quarterScores: Record<string, number[]> = {
+        [teamA.id]: [0, 0, 0, 0],
+        [teamB.id]: [0, 0, 0, 0]
+    };
 
-    let remainTime = quarterTime;
+    const boxscore: Record<string, Record<string, PlayerStats>> = {
+        [teamA.id]: {},
+        [teamB.id]: {}
+    };
 
-    while (remainTime > 0) {
-      const possessionTime = Math.random() * (24 - 5) + 5;
-      remainTime -= possessionTime;
+    const events: string[] = [];
 
-      await sleep(1);
-      if (remainTime < 0) break;
+    const quarters = 4;
+    const quarterTime = 12 * 60;
 
-      const minute = Math.floor(remainTime / 60);
-      const second = Math.floor(remainTime % 60);
+    const playersA: Player[] = teamA.players.map(p => ({ ...p }));
+    const playersB: Player[] = teamB.players.map(p => ({ ...p }));
 
-      // Recuperação de energia dos jogadores no banco
-      const benchA = playersA.filter(p => !onCourtA.includes(p));
-      const benchB = playersB.filter(p => !onCourtB.includes(p));
-      [...benchA, ...benchB].forEach(p => {
-        p.energy = Math.min(100, p.energy + (10 * possessionTime) / 60);
-      });
+    const starters: Record<string, Player[]> = {
+        [teamA.id]: getStarters(playersA),
+        [teamB.id]: getStarters(playersB),
+    };
 
-      if (Math.random() < 0.1) continue;
+    const bench: Record<string, Player[]> = {
+        [teamA.id]: playersA.filter(p => !starters[teamA.id].includes(p)),
+        [teamB.id]: playersB.filter(p => !starters[teamB.id].includes(p)),
+    };
 
-      const isTeamA = Math.random() < 0.5;
-      const attackingTeam = isTeamA ? onCourtA : onCourtB;
-      const defendingTeam = isTeamA ? onCourtB : onCourtA;
-      const teamId = isTeamA ? teamA.id : teamB.id;
+    let onCourtA = starters[teamA.id];
+    let onCourtB = starters[teamB.id];
 
-      const attacker = attackingTeam[Math.floor(Math.random() * attackingTeam.length)];
-      const defender = defendingTeam[Math.floor(Math.random() * defendingTeam.length)];
-      const stats = boxscore[teamId][attacker.name];
+    // inicializa stats
+    [...playersA, ...playersB].forEach(p => {
+        boxscore[p.teamId] = boxscore[p.teamId] || {};
+        boxscore[p.teamId][p.name] = {
+            points: 0,
+            fgm: 0,
+            fga: 0,
+            tpm: 0,
+            tpa: 0,
+            ftm: 0,
+            fta: 0,
+            energy: p.energy
+        };
+    });
 
-      const rand = Math.random();
-      let points = 0;
-      let chance = 0;
-      let shotType = '';
+    for (let q = 1; q <= quarters; q++) {
+        events.push(`--- Quarter ${q} ---`);
+        if (onUpdate) onUpdate([...events], { ...score }, { ...quarterScores }, { ...boxscore }, starters, bench);
 
-      if (rand < 0.70) {
-        points = 2;
-        shotType = '2PT';
-        chance = attacker.attack / (attacker.attack + defender.defense) * (attacker.energy / 55);
-        stats.fga++;
-      } else if (rand < 0.95) {
-        points = 3;
-        shotType = '3PT';
-        chance = (attacker.attack * 0.8) / (attacker.attack + defender.defense) * (attacker.energy / 70);
-        stats.fga++;
-        stats.tpa++;
-      } else {
-        points = 1;
-        shotType = 'FT';
-        chance = attacker.energy / 100;
-      }
+        let remainTime = quarterTime;
 
-      if (shotType === 'FT') {
-        for (let ft = 1; ft <= 2; ft++) {
-          if (randomChance(chance)) {
-            score[teamId] += 1;
-            quarterScores[teamId][q - 1] += 1;
-            stats.points += 1;
-            stats.ftm += 1;
-            stats.fta += 1;
-            events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} acerta um ${shotType}!`);
-          } else {
-            stats.fta += 1;
-            events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} erra um ${shotType}.`);
-          }
+        while (remainTime > 0) {
+            if (paused) {
+                await new Promise<void>(resolve => { resolvePause = resolve });
+            }
+            const possessionTime = Math.random() * (24 - 5) + 5;
+            remainTime -= possessionTime;
+
+            await sleep(1000);
+            if (remainTime < 0) break;
+
+            const minute = Math.floor(remainTime / 60);
+            const second = Math.floor(remainTime % 60);
+
+            if (Math.random() < 0.1) continue;
+
+            const isTeamA = Math.random() < 0.5;
+            const attackingTeam = isTeamA ? starters[teamA.id] : starters[teamB.id];
+            const defendingTeam = isTeamA ? starters[teamB.id] : starters[teamA.id];
+            const teamId = isTeamA ? teamA.id : teamB.id;
+
+            const attacker = attackingTeam[Math.floor(Math.random() * attackingTeam.length)];
+            const defender = defendingTeam[Math.floor(Math.random() * defendingTeam.length)];
+            const stats = boxscore[teamId][attacker.name];
+
+            const rand = Math.random();
+            let points = 0;
+            let chance = 0;
+            let shotType = '';
+
+            if (rand < 0.70) {
+                points = 2;
+                shotType = '2PT';
+                chance = attacker.attack / (attacker.attack + defender.defense) * (attacker.energy / 55);
+                stats.fga++;
+            } else if (rand < 0.95) {
+                points = 3;
+                shotType = '3PT';
+                chance = (attacker.attack * 0.8) / (attacker.attack + defender.defense) * (attacker.energy / 70);
+                stats.fga++;
+                stats.tpa++;
+            } else {
+                points = 1;
+                shotType = 'FT';
+                chance = attacker.energy / 100;
+            }
+
+            if (shotType === 'FT') {
+                for (let ft = 1; ft <= 2; ft++) {
+                    if (randomChance(chance)) {
+                        score[teamId] += 1;
+                        quarterScores[teamId][q - 1] += 1;
+                        stats.points += 1;
+                        stats.ftm += 1;
+                        stats.fta += 1;
+                        events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} acerta um ${shotType}!`);
+                    } else {
+                        stats.fta += 1;
+                        events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} erra um ${shotType}.`);
+                    }
+                }
+            } else {
+                if (randomChance(chance)) {
+                    score[teamId] += points;
+                    quarterScores[teamId][q - 1] += points;
+                    stats.points += points;
+                    stats.fgm++;
+                    if (points === 3) stats.tpm++;
+                    events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} marca ${points} pontos (${shotType}).`);
+                } else {
+                    events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} erra um ${shotType}.`);
+                }
+            }
+            
+            // Reduz energia do atacante
+            attacker.energy = Math.max(attacker.energy - 5, 0);
+            stats.energy = attacker.energy;
+
+            // Recuperação de energia dos jogadores no banco
+            const benchA = bench[teamA.id];
+            const benchB = bench[teamB.id];
+            [...benchA, ...benchB].forEach(p => {
+                p.energy = Math.min(100, p.energy + 0.1);
+                boxscore[p.teamId][p.name].energy = p.energy;
+            });
+
+            // Reduz energia dos jogadores em quadra
+            const onCourtA = starters[teamA.id];
+            const onCourtB = starters[teamB.id];
+            [...onCourtA, ...onCourtB].forEach(p => {
+                p.energy = Math.max(p.energy - 1);
+                boxscore[p.teamId][p.name].energy = p.energy;
+            });
+
+            if (onUpdate) onUpdate([...events], { ...score }, { ...quarterScores }, { ...boxscore }, starters, bench);
         }
-      } else {
-        if (randomChance(chance)) {
-          score[teamId] += points;
-          quarterScores[teamId][q - 1] += points;
-          stats.points += points;
-          stats.fgm++;
-          if (points === 3) stats.tpm++;
-          events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} marca ${points} pontos (${shotType}).`);
-        } else {
-          events.push(`[${minute}:${second < 10 ? '0' : ''}${second}] ${attacker.name} erra um ${shotType}.`);
-        }
-      }
-
-      attacker.energy = Math.max(attacker.energy - 5, 0);
-
-      // Substituição automática
-      if (attacker.energy < 40) {
-        substitutePlayer(isTeamA ? playersA : playersB, isTeamA ? onCourtA : onCourtB, attacker.position, events, minute, second);
-      }
-
-      stats.energy = attacker.energy;
-
-      if (onUpdate) onUpdate([...events], { ...score }, { ...quarterScores }, { ...boxscore });
     }
-  }
 
-  return { score, quarterScores, events, boxscore };
+    return { score, quarterScores, events, boxscore, starters, bench };
 }


### PR DESCRIPTION
Implementado suporte para substituições manuais durante a simulação:

- Apenas 5 titulares em quadra (1 por posição).
- Possibilidade de pausar o jogo e abrir painel de substituições.
- Permite trocar titulares por jogadores do banco manualmente.
- Simulação pode ser retomada após as substituições.
- Jogadores no banco recuperam 0.1 de energia a cada segundo de partida

Essa mudança melhora o realismo e adiciona controle estratégico ao técnico durante a partida.